### PR TITLE
Fix typo in "ApiCredentials" & Improve "TimestampSecondsConverter"

### DIFF
--- a/CryptoExchange.Net/Authentication/ApiCredentials.cs
+++ b/CryptoExchange.Net/Authentication/ApiCredentials.cs
@@ -26,7 +26,7 @@ namespace CryptoExchange.Net.Authentication
         /// <param name="privateKey">The private key used for signing</param>
         public ApiCredentials(SecureString privateKey)
         {
-            PrivateKey = Key;
+            PrivateKey = privateKey;
         }
 
         /// <summary>

--- a/CryptoExchange.Net/Converters/TimestampSecondsConverter.cs
+++ b/CryptoExchange.Net/Converters/TimestampSecondsConverter.cs
@@ -13,7 +13,7 @@ namespace CryptoExchange.Net.Converters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var t = double.Parse((string)reader.Value, CultureInfo.InvariantCulture);
+            var t = double.Parse((string)reader.Value.ToString(), CultureInfo.InvariantCulture);
             return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(t);
         }
 

--- a/CryptoExchange.Net/Converters/TimestampSecondsConverter.cs
+++ b/CryptoExchange.Net/Converters/TimestampSecondsConverter.cs
@@ -13,7 +13,7 @@ namespace CryptoExchange.Net.Converters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var t = double.Parse((string)reader.Value.ToString(), CultureInfo.InvariantCulture);
+            var t = double.Parse(reader.Value.ToString(), CultureInfo.InvariantCulture);
             return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(t);
         }
 


### PR DESCRIPTION
Hi @JKorf,

- [X] Typo fixed in  `public ApiCredentials(SecureString privateKey)`
- [X] Inputs such as `double`, `long`, (...) can now be deserialized by `TimestampSecondsConverter`

Have a good day.