### PR TITLE
Properties can now be optional

### DIFF
--- a/CryptoExchange.Net/Attributes/JsonOptionalPropertyAttribute.cs
+++ b/CryptoExchange.Net/Attributes/JsonOptionalPropertyAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CryptoExchange.Net.Attributes
+{
+    public class JsonOptionalPropertyAttribute : Attribute
+    {
+        public JsonOptionalPropertyAttribute() { }
+    }
+}

--- a/CryptoExchange.Net/ExchangeClient.cs
+++ b/CryptoExchange.Net/ExchangeClient.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
+using CryptoExchange.Net.Attributes;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Interfaces;
 using CryptoExchange.Net.Logging;
@@ -294,6 +295,12 @@ namespace CryptoExchange.Net
 
             foreach (var prop in properties)
             {
+                var propInfo = props.FirstOrDefault(p => p.Name == prop ||
+                    ((JsonPropertyAttribute)p.GetCustomAttributes(typeof(JsonPropertyAttribute), false).FirstOrDefault())?.PropertyName == prop);
+                var optional = propInfo.GetCustomAttributes(typeof(JsonOptionalPropertyAttribute), false).FirstOrDefault();
+                if (optional != null)
+                    continue;
+
                 isDif = true;
                 log.Write(LogVerbosity.Warning, $"Didn't find key `{prop}` in returned data object of type `{type.Name}`");
             }


### PR DESCRIPTION
Hi @JKorf,

Another little PR to **make properties optional**, **if desired**.
This can be useful when two endpoints return the same response with one or two more fields (_but without changing the meaning of the class_). This allows classes to be reused.

Thanks,
Good night.