### PR TITLE
Encrypted private keys can now be passed in Api Credentials

### DIFF
--- a/CryptoExchange.Net/Authentication/ApiCredentials.cs
+++ b/CryptoExchange.Net/Authentication/ApiCredentials.cs
@@ -30,7 +30,7 @@ namespace CryptoExchange.Net.Authentication
         }
 
         /// <summary>
-        /// Create Api credentials providing a api key and secret for authenciation
+        /// Create Api credentials providing a api key and secret for authentication
         /// </summary>
         /// <param name="key">The api key used for identification</param>
         /// <param name="secret">The api secret used for signing</param>
@@ -41,7 +41,7 @@ namespace CryptoExchange.Net.Authentication
         }
 
         /// <summary>
-        /// Create Api credentials providing a api key and secret for authenciation
+        /// Create Api credentials providing a api key and secret for authentication
         /// </summary>
         /// <param name="key">The api key used for identification</param>
         /// <param name="secret">The api secret used for signing</param>

--- a/CryptoExchange.Net/Authentication/ApiCredentials.cs
+++ b/CryptoExchange.Net/Authentication/ApiCredentials.cs
@@ -18,31 +18,15 @@ namespace CryptoExchange.Net.Authentication
         /// <summary>
         /// The private key to authenticate requests
         /// </summary>
-        public SecureString PrivateKey { get; }
+        public PrivateKey PrivateKey { get; }
 
         /// <summary>
-        /// Create Api credentials providing a private key for authenication
+        /// Create Api credentials providing a private key for authentication
         /// </summary>
         /// <param name="privateKey">The private key used for signing</param>
-        public ApiCredentials(SecureString privateKey)
+        public ApiCredentials(PrivateKey privateKey)
         {
             PrivateKey = privateKey;
-        }
-
-        /// <summary>
-        /// Create Api credentials providing a private key for authenication
-        /// </summary>
-        /// <param name="privateKey">The private key used for signing</param>
-        public ApiCredentials(string privateKey)
-        {
-            if(string.IsNullOrEmpty(privateKey))
-                throw new ArgumentException("Private key can't be null/empty");
-
-            var securePrivateKey = new SecureString();
-            foreach (var c in privateKey)
-                securePrivateKey.AppendChar(c);
-            securePrivateKey.MakeReadOnly();
-            PrivateKey = securePrivateKey;
         }
 
         /// <summary>

--- a/CryptoExchange.Net/Authentication/PrivateKey.cs
+++ b/CryptoExchange.Net/Authentication/PrivateKey.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security;
+using System.Text;
+
+namespace CryptoExchange.Net.Authentication
+{
+    public class PrivateKey : IDisposable
+    {
+        /// <summary>
+        /// The private key
+        /// </summary>
+        public SecureString Key { get; }
+
+        /// <summary>
+        /// The private key's passphrase
+        /// </summary>
+        public SecureString Passphrase { get; }
+
+        /// <summary>
+        /// Indicates if the private key is encrypted or not
+        /// </summary>
+        public bool IsEncrypted { get; }
+
+        /// <summary>
+        /// Create a private key providing an encrypted key informations
+        /// </summary>
+        /// <param name="key">The private key used for signing</param>
+        /// <param name="passphrase">The private key's passphrase</param>
+        public PrivateKey(SecureString key, SecureString passphrase)
+        {
+            Key = key;
+            Passphrase = passphrase;
+
+            IsEncrypted = true;
+        }
+
+        /// <summary>
+        /// Create a private key providing an encrypted key informations
+        /// </summary>
+        /// <param name="key">The private key used for signing</param>
+        /// <param name="passphrase">The private key's passphrase</param>
+        public PrivateKey(string key, string passphrase)
+        {
+            if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(passphrase))
+                throw new ArgumentException("Key and passphrase can't be null/empty");
+
+            var secureKey = new SecureString();
+            foreach (var c in key)
+                secureKey.AppendChar(c);
+            secureKey.MakeReadOnly();
+            Key = secureKey;
+
+            var securePassphrase = new SecureString();
+            foreach (var c in passphrase)
+                securePassphrase.AppendChar(c);
+            securePassphrase.MakeReadOnly();
+            Passphrase = securePassphrase;
+
+            IsEncrypted = true;
+        }
+
+        /// <summary>
+        /// Create a private key providing an unencrypted key informations
+        /// </summary>
+        /// <param name="key">The private key used for signing</param>
+        public PrivateKey(SecureString key)
+        {
+            Key = key;
+
+            IsEncrypted = false;
+        }
+
+        /// <summary>
+        /// Create a private key providing an encrypted key informations
+        /// </summary>
+        /// <param name="key">The private key used for signing</param>
+        public PrivateKey(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException("Key can't be null/empty");
+
+            var secureKey = new SecureString();
+            foreach (var c in key)
+                secureKey.AppendChar(c);
+            secureKey.MakeReadOnly();
+            Key = secureKey;
+
+            IsEncrypted = false;
+        }
+
+        public void Dispose()
+        {
+            Key?.Dispose();
+            Passphrase?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Hi @JKorf,

The old model of _ApiCredentials_ does not allow to pass encrypted private keys because we needed to pass a passphrase for them.

I first thought about adding a _**Passphrase**_ property directly in _ApiCredentials_ but I realized that there was going to be a problem for overloading constructor as these are the same types of parameters.
I then thought about sharing **_Key_** and **_Secret_** properties for API key authentication and private keys authentications , but that would have been too ambiguous.

So I opted for this solution, if you have a better one, I'm interested :blush:.

Have a good day.