### PR TITLE
Ticking price event

### DIFF
--- a/CryptoExchange.Net/CryptoExchange.Net.xml
+++ b/CryptoExchange.Net/CryptoExchange.Net.xml
@@ -797,6 +797,11 @@
             Event when order book was updated. Be careful! It can generate a lot of events at high-liquidity markets
             </summary>    
         </member>
+        <member name="E:CryptoExchange.Net.Interfaces.ISymbolOrderBook.OnPriceChanged">
+            <summary>
+            Event when the BestBid or BestAsk changes ie a Pricing Tick
+            </summary>
+        </member>
         <member name="P:CryptoExchange.Net.Interfaces.ISymbolOrderBook.LastOrderBookUpdate">
             <summary>
             Timestamp of the last update
@@ -1767,6 +1772,11 @@
         <member name="E:CryptoExchange.Net.OrderBook.SymbolOrderBook.OnStatusChange">
             <summary>
             Event when the state changes
+            </summary>
+        </member>
+        <member name="E:CryptoExchange.Net.OrderBook.SymbolOrderBook.OnPriceChanged">
+            <summary>
+            Event when the BestBid or BestAsk changes ie a Pricing Tick
             </summary>
         </member>
         <member name="E:CryptoExchange.Net.OrderBook.SymbolOrderBook.OnOrderBookUpdate">
@@ -2887,6 +2897,149 @@
         </member>
         <member name="M:CryptoExchange.Net.Sockets.WebsocketFactory.CreateWebsocket(CryptoExchange.Net.Logging.Log,System.String,System.Collections.Generic.IDictionary{System.String,System.String},System.Collections.Generic.IDictionary{System.String,System.String})">
             <inheritdoc />
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.AllowNullAttribute">
+            <summary>
+                Specifies that <see langword="null"/> is allowed as an input even if the
+                corresponding type disallows it.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.AllowNullAttribute.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:System.Diagnostics.CodeAnalysis.AllowNullAttribute"/> class.
+            </summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DisallowNullAttribute">
+            <summary>
+                Specifies that <see langword="null"/> is disallowed as an input even if the
+                corresponding type allows it.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.DisallowNullAttribute.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:System.Diagnostics.CodeAnalysis.DisallowNullAttribute"/> class.
+            </summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute">
+            <summary>
+                Specifies that a method that will never return under any circumstance.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute"/> class.
+            </summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute">
+            <summary>
+                Specifies that the method will not return if the associated <see cref="T:System.Boolean"/>
+                parameter is passed the specified value.
+            </summary>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.ParameterValue">
+            <summary>
+                Gets the condition parameter value.
+                Code after the method is considered unreachable by diagnostics if the argument
+                to the associated parameter matches this value.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.#ctor(System.Boolean)">
+            <summary>
+                Initializes a new instance of the <see cref="T:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute"/>
+                class with the specified parameter value.
+            </summary>
+            <param name="parameterValue">
+                The condition parameter value.
+                Code after the method is considered unreachable by diagnostics if the argument
+                to the associated parameter matches this value.
+            </param>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MaybeNullAttribute">
+            <summary>
+                Specifies that an output may be <see langword="null"/> even if the
+                corresponding type disallows it.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MaybeNullAttribute.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:System.Diagnostics.CodeAnalysis.MaybeNullAttribute"/> class.
+            </summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute">
+            <summary>
+                Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue"/>, 
+                the parameter may be <see langword="null"/> even if the corresponding type disallows it.
+            </summary>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue">
+            <summary>
+                Gets the return value condition.
+                If the method returns this value, the associated parameter may be <see langword="null"/>.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.#ctor(System.Boolean)">
+            <summary>
+                 Initializes the attribute with the specified return value condition.
+            </summary>
+            <param name="returnValue">
+                The return value condition.
+                If the method returns this value, the associated parameter may be <see langword="null"/>.
+            </param>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullAttribute">
+            <summary>
+                Specifies that an output is not <see langword="null"/> even if the
+                corresponding type allows it.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullAttribute.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:System.Diagnostics.CodeAnalysis.NotNullAttribute"/> class.
+            </summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute">
+            <summary>
+                Specifies that the output will be non-<see langword="null"/> if the
+                named parameter is non-<see langword="null"/>.
+            </summary>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.ParameterName">
+            <summary>
+                Gets the associated parameter name.
+                The output will be non-<see langword="null"/> if the argument to the
+                parameter specified is non-<see langword="null"/>.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.#ctor(System.String)">
+            <summary>
+                Initializes the attribute with the associated parameter name.
+            </summary>
+            <param name="parameterName">
+                The associated parameter name.
+                The output will be non-<see langword="null"/> if the argument to the
+                parameter specified is non-<see langword="null"/>.
+            </param>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute">
+            <summary>
+                Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue"/>,
+                the parameter will not be <see langword="null"/> even if the corresponding type allows it.
+            </summary>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue">
+            <summary>
+                Gets the return value condition.
+                If the method returns this value, the associated parameter will not be <see langword="null"/>.
+            </summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.#ctor(System.Boolean)">
+            <summary>
+                Initializes the attribute with the specified return value condition.
+            </summary>
+            <param name="returnValue">
+                The return value condition.
+                If the method returns this value, the associated parameter will not be <see langword="null"/>.
+            </param>
         </member>
     </members>
 </doc>

--- a/CryptoExchange.Net/Interfaces/ISymbolOrderBook.cs
+++ b/CryptoExchange.Net/Interfaces/ISymbolOrderBook.cs
@@ -33,6 +33,10 @@ namespace CryptoExchange.Net.Interfaces
         /// </summary>    
         event Action<IEnumerable<ISymbolOrderBookEntry>, IEnumerable<ISymbolOrderBookEntry>> OnOrderBookUpdate;
         /// <summary>
+        /// Event when the BestBid or BestAsk changes ie a Pricing Tick
+        /// </summary>
+        event Action<ISymbolOrderBookEntry, ISymbolOrderBookEntry> OnPriceChanged;
+        /// <summary>
         /// Timestamp of the last update
         /// </summary>
         DateTime LastOrderBookUpdate { get; }

--- a/CryptoExchange.Net/OrderBook/SymbolOrderBook.cs
+++ b/CryptoExchange.Net/OrderBook/SymbolOrderBook.cs
@@ -51,7 +51,7 @@ namespace CryptoExchange.Net.OrderBook
         /// <summary>
         /// The status of the order book. Order book is up to date when the status is `Synced`
         /// </summary>
-        public OrderBookStatus Status
+        public OrderBookStatus Status 
         {
             get => status;
             set
@@ -79,6 +79,12 @@ namespace CryptoExchange.Net.OrderBook
         /// Event when the state changes
         /// </summary>
         public event Action<OrderBookStatus, OrderBookStatus>? OnStatusChange;
+
+        /// <summary>
+        /// Event when the BestBid or BestAsk changes ie a Pricing Tick
+        /// </summary>
+        public event Action<ISymbolOrderBookEntry, ISymbolOrderBookEntry>? OnPriceChanged;
+
         /// <summary>
         /// Event when order book was updated, containing the changed bids and asks. Be careful! It can generate a lot of events at high-liquidity markets
         /// </summary>
@@ -112,7 +118,7 @@ namespace CryptoExchange.Net.OrderBook
         /// <summary>
         /// The list of bids
         /// </summary>
-        public IEnumerable<ISymbolOrderBookEntry> Bids
+        public IEnumerable<ISymbolOrderBookEntry> Bids 
         {
             get
             {
@@ -136,7 +142,7 @@ namespace CryptoExchange.Net.OrderBook
         /// <summary>
         /// The best ask currently in the order book
         /// </summary>
-        public ISymbolOrderBookEntry BestAsk
+        public ISymbolOrderBookEntry BestAsk 
         {
             get
             {
@@ -286,7 +292,14 @@ namespace CryptoExchange.Net.OrderBook
                 log.Write(LogVerbosity.Debug, $"{Id} order book {Symbol} data set: {BidCount} bids, {AskCount} asks. #{orderBookSequenceNumber}");
                 CheckProcessBuffer();
                 OnOrderBookUpdate?.Invoke(bidList, askList);
+                OnPriceChanged?.Invoke(BestBid, BestAsk);
             }
+        }
+
+        private bool BestPricingUpdated(ISymbolOrderBookEntry prevBestBid, ISymbolOrderBookEntry prevBestAsk)
+        {
+            return BestBid.Price != prevBestBid.Price || BestBid.Quantity != prevBestBid.Quantity ||
+                   BestAsk.Price != prevBestAsk.Price || BestAsk.Quantity != prevBestAsk.Quantity;
         }
 
         /// <summary>
@@ -315,8 +328,12 @@ namespace CryptoExchange.Net.OrderBook
                 else
                 {
                     CheckProcessBuffer();
+                    var prevBestBid = BestBid;
+                    var prevBestAsk = BestAsk;
                     ProcessSingleSequenceUpdates(rangeUpdateId, bids, asks);
                     OnOrderBookUpdate?.Invoke(bids, asks);
+                    if (BestPricingUpdated(prevBestBid, prevBestAsk))
+                        OnPriceChanged?.Invoke(BestBid, BestAsk);
                 }
             }
         }
@@ -349,8 +366,12 @@ namespace CryptoExchange.Net.OrderBook
                 else
                 {
                     CheckProcessBuffer();
+                    var prevBestBid = BestBid;
+                    var prevBestAsk = BestAsk;
                     ProcessRangeUpdates(firstUpdateId, lastUpdateId, bids, asks);
                     OnOrderBookUpdate?.Invoke(bids, asks);
+                    if (BestPricingUpdated(prevBestBid, prevBestAsk))
+                        OnPriceChanged?.Invoke(BestBid, BestAsk);
                 }
             }
         }
@@ -376,8 +397,13 @@ namespace CryptoExchange.Net.OrderBook
                 else
                 {
                     CheckProcessBuffer();
+                    var prevBestBid = BestBid;
+                    var prevBestAsk = BestAsk;
                     ProcessUpdates(bids, asks);
                     OnOrderBookUpdate?.Invoke(bids, asks);
+                    if (BestPricingUpdated(prevBestBid, prevBestAsk))
+                        OnPriceChanged?.Invoke(BestBid, BestAsk);
+
                 }
             }
         }


### PR DESCRIPTION
I would like to use SymbolOrderBook and remove the implementation in my own appication, however I need an update event when the BestBid or BestAsk changes.  In short I want a tick event when an oderbook update results in a best price or qty change.

Im sure others would find this useful and cuts down on the noise of the OnOrderBookUpdate as the payload is much smaller and the frequency will be lower.

I didn't want to overload equality on ISymbolOrderBookEntry as could be used in a different way in the other implementing Exchanges so I opted for a private comparer function.  Excuse my c# I have not written any for a while as mainly functional these days.