### PR TITLE
Execute request without returning data

### DIFF
--- a/CryptoExchange.Net/CryptoExchange.Net.xml
+++ b/CryptoExchange.Net/CryptoExchange.Net.xml
@@ -1233,6 +1233,33 @@
             </summary>
             <param name="obj"></param>
         </member>
+        <member name="T:CryptoExchange.Net.Objects.CallResult">
+            <summary>
+            The result of an operation
+            </summary>
+        </member>
+        <member name="P:CryptoExchange.Net.Objects.CallResult.Error">
+            <summary>
+            An error if the call didn't succeed
+            </summary>
+        </member>
+        <member name="P:CryptoExchange.Net.Objects.CallResult.Success">
+            <summary>
+            Whether the call was successful
+            </summary>
+        </member>
+        <member name="M:CryptoExchange.Net.Objects.CallResult.#ctor(CryptoExchange.Net.Objects.Error)">
+            <summary>
+            ctor
+            </summary>
+            <param name="error"></param>
+        </member>
+        <member name="M:CryptoExchange.Net.Objects.CallResult.op_Implicit(CryptoExchange.Net.Objects.CallResult)~System.Boolean">
+            <summary>
+            Overwrite bool check so we can use if(callResult) instead of if(callResult.Success)
+            </summary>
+            <param name="obj"></param>
+        </member>
         <member name="T:CryptoExchange.Net.Objects.WebCallResult`1">
             <summary>
             The result of a request
@@ -1266,6 +1293,45 @@
             <returns></returns>
         </member>
         <member name="M:CryptoExchange.Net.Objects.WebCallResult`1.CreateErrorResult(System.Nullable{System.Net.HttpStatusCode},System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Collections.Generic.IEnumerable{System.String}}},CryptoExchange.Net.Objects.Error)">
+            <summary>
+            Create an error result
+            </summary>
+            <param name="code"></param>
+            <param name="responseHeaders"></param>
+            <param name="error"></param>
+            <returns></returns>
+        </member>
+        <member name="T:CryptoExchange.Net.Objects.WebCallResult">
+            <summary>
+            The result of a request
+            </summary>
+        </member>
+        <member name="P:CryptoExchange.Net.Objects.WebCallResult.ResponseStatusCode">
+            <summary>
+            The status code of the response. Note that a OK status does not always indicate success, check the Success parameter for this.
+            </summary>
+        </member>
+        <member name="P:CryptoExchange.Net.Objects.WebCallResult.ResponseHeaders">
+            <summary>
+            The response headers
+            </summary>
+        </member>
+        <member name="M:CryptoExchange.Net.Objects.WebCallResult.#ctor(System.Nullable{System.Net.HttpStatusCode},System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Collections.Generic.IEnumerable{System.String}}},CryptoExchange.Net.Objects.Error)">
+            <summary>
+            ctor
+            </summary>
+            <param name="code"></param>
+            <param name="responseHeaders"></param>
+            <param name="error"></param>
+        </member>
+        <member name="M:CryptoExchange.Net.Objects.WebCallResult.CreateErrorResult(CryptoExchange.Net.Objects.Error)">
+            <summary>
+            Create an error result
+            </summary>
+            <param name="error"></param>
+            <returns></returns>
+        </member>
+        <member name="M:CryptoExchange.Net.Objects.WebCallResult.CreateErrorResult(System.Nullable{System.Net.HttpStatusCode},System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Collections.Generic.IEnumerable{System.String}}},CryptoExchange.Net.Objects.Error)">
             <summary>
             Create an error result
             </summary>
@@ -2225,6 +2291,19 @@
             <param name="parameters">The parameters of the request</param>
             <param name="signed">Whether or not the request should be authenticated</param>
             <param name="checkResult">Whether or not the resulting object should be checked for missing properties in the mapping (only outputs if log verbosity is Debug)</param> 
+            <param name="postPosition">Where the post parameters should be placed</param>
+            <param name="arraySerialization">How array parameters should be serialized</param>
+            <returns></returns>
+        </member>
+        <member name="M:CryptoExchange.Net.RestClient.SendRequest(System.Uri,System.Net.Http.HttpMethod,System.Threading.CancellationToken,System.Collections.Generic.Dictionary{System.String,System.Object},System.Boolean,System.Nullable{CryptoExchange.Net.Objects.PostParameters},System.Nullable{CryptoExchange.Net.Objects.ArrayParametersSerialization})">
+            <summary>
+            Execute a request
+            </summary>
+            <param name="uri">The uri to send the request to</param>
+            <param name="method">The method of the request</param>
+            <param name="cancellationToken">Cancellation token</param>
+            <param name="parameters">The parameters of the request</param>
+            <param name="signed">Whether or not the request should be authenticated</param>
             <param name="postPosition">Where the post parameters should be placed</param>
             <param name="arraySerialization">How array parameters should be serialized</param>
             <returns></returns>

--- a/CryptoExchange.Net/Objects/CallResult.cs
+++ b/CryptoExchange.Net/Objects/CallResult.cs
@@ -43,12 +43,45 @@ namespace CryptoExchange.Net.Objects
             return obj?.Success == true;
         }
     }
+    
+    /// <summary>
+    /// The result of an operation
+    /// </summary>
+    public class CallResult
+    {
+        /// <summary>
+        /// An error if the call didn't succeed
+        /// </summary>
+        public Error? Error { get; internal set; }
+        /// <summary>
+        /// Whether the call was successful
+        /// </summary>
+        public bool Success => Error == null;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="error"></param>
+        public CallResult(Error? error)
+        {
+            Error = error;
+        }
+
+        /// <summary>
+        /// Overwrite bool check so we can use if(callResult) instead of if(callResult.Success)
+        /// </summary>
+        /// <param name="obj"></param>
+        public static implicit operator bool(CallResult obj)
+        {
+            return obj?.Success == true;
+        }
+    }
 
     /// <summary>
     /// The result of a request
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class WebCallResult<T>: CallResult<T>
+    public class WebCallResult<T> : CallResult<T>
     {
         /// <summary>
         /// The status code of the response. Note that a OK status does not always indicate success, check the Success parameter for this.
@@ -95,6 +128,58 @@ namespace CryptoExchange.Net.Objects
         public static WebCallResult<T> CreateErrorResult(HttpStatusCode? code, IEnumerable<KeyValuePair<string, IEnumerable<string>>>? responseHeaders, Error error)
         {
             return new WebCallResult<T>(code, responseHeaders, default!, error);
+        }
+    }
+
+    /// <summary>
+    /// The result of a request
+    /// </summary>
+    public class WebCallResult : CallResult
+    {
+        /// <summary>
+        /// The status code of the response. Note that a OK status does not always indicate success, check the Success parameter for this.
+        /// </summary>
+        public HttpStatusCode? ResponseStatusCode { get; set; }
+
+        /// <summary>
+        /// The response headers
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, IEnumerable<string>>>? ResponseHeaders { get; set; }
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="responseHeaders"></param>
+        /// <param name="error"></param>
+        public WebCallResult(HttpStatusCode? code, 
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>>? responseHeaders, Error? error): base(error)
+        {
+            ResponseHeaders = responseHeaders;
+            ResponseStatusCode = code;
+        }
+
+        /// <summary>
+        /// Create an error result
+        /// </summary>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        public static WebCallResult CreateErrorResult(Error error)
+        {
+            return new WebCallResult(null, null, error);
+        }
+
+        /// <summary>
+        /// Create an error result
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="responseHeaders"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        public static WebCallResult CreateErrorResult(HttpStatusCode? code, 
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>>? responseHeaders, Error error)
+        {
+            return new WebCallResult(code, responseHeaders, error);
         }
     }
 }


### PR DESCRIPTION
Some exchange API methods returns empty result. 
Wrapper for the API may returns CallResult/WebCallResult without null object.