### PR TITLE
Update CallResult.cs

### DIFF
--- a/CryptoExchange.Net/Objects/CallResult.cs
+++ b/CryptoExchange.Net/Objects/CallResult.cs
@@ -35,6 +35,30 @@ namespace CryptoExchange.Net.Objects
         }
 
         /// <summary>
+        /// Whether the call was successful or not.
+        /// </summary>
+        /// <param name="data">The data returned by the call.</param>
+        /// <param name="error"><see cref="Error"/> on failure.</param>
+        /// <returns><c>true</c> when <see cref="CallResult{T}"/> succeeded, <c>false</c> otherwise.</returns>
+        public bool GetResultOrError([MaybeNullWhen(false)] out T data, [NotNullWhen(false)] out Error? error)
+        {
+            if (Success)
+            {
+                data = Data!;
+                error = null;
+
+                return true;
+            }
+            else
+            {
+                data = default;
+                error = Error!;
+
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Overwrite bool check so we can use if(callResult) instead of if(callResult.Success)
         /// </summary>
         /// <param name="obj"></param>
@@ -68,7 +92,7 @@ namespace CryptoExchange.Net.Objects
         /// <param name="data"></param>
         /// <param name="error"></param>
         public WebCallResult(
-            HttpStatusCode? code, 
+            HttpStatusCode? code,
             IEnumerable<KeyValuePair<string, IEnumerable<string>>>? responseHeaders, [AllowNull] T data, Error? error): base(data, error)
         {
             ResponseHeaders = responseHeaders;


### PR DESCRIPTION
This is just an idea. There are possibly many things to consider further but ...

With the PR, you can write the following code and there is no warning with regard to nullability of `CallResult` fields:

```csharp
CallResult<UpdateSubscription> task = await this.webSocketClient.Spot.SubscribeToUserDataUpdatesAsync(/* ... */).ConfigureAwait(false);

if (task.IsSuccess(out Error? error))
{
    this.log.Debug("Success!");
}
else
{
    this.log.Error("Failed to subscribe user data update via WebSocket. Error: '{0}'.", error.ToString());
}
```

as opposed to:

```csharp
CallResult<UpdateSubscription> task = await this.webSocketClient.Spot.SubscribeToUserDataUpdatesAsync(/* ... */).ConfigureAwait(false);

if (task.Success)
{
    this.log.Debug("Success!");
}
else
{
    this.log.Error("Failed to subscribe user data update via WebSocket. Error: '{0}'.", task.Error!.ToString());
}
```

Note: `IsSuccess` is not the best name but I can't come up with any better at the moment.

**EDIT:** Maybe, this is even better:

```csharp
/// <summary>
/// Whether the call was successful or not.
/// </summary>
/// <param name="data">The data returned by the call.</param>
/// <param name="error"><see cref="Error"/> on failure.</param>
/// <returns><c>true</c> when <see cref="CallResult{T}"/> succeeded, <c>false</c> otherwise.</returns>
public bool GetResultOrError([NotNullWhen(true)] out T data, [NotNullWhen(false)] out Error? error)
{
    data = Success ? Data : default;
    error = Success ? null : Error;
    return Success;
}
```