### PR TITLE
Fix for issue #71

### DIFF
--- a/CryptoExchange.Net/Sockets/SocketConnection.cs
+++ b/CryptoExchange.Net/Sockets/SocketConnection.cs
@@ -153,6 +153,10 @@ namespace CryptoExchange.Net.Sockets
                 if (pendingRequest.Check(tokenData))
                 {
                     pendingRequests.Remove(pendingRequest);
+                    if (pendingRequest.Result == null)
+					{
+                        continue; // A previous timeout.
+					}
                     if (!socketClient.ContinueOnQueryResponse)
                         return;
                     handledResponse = true;

--- a/CryptoExchange.Net/Sockets/SocketConnection.cs
+++ b/CryptoExchange.Net/Sockets/SocketConnection.cs
@@ -148,11 +148,19 @@ namespace CryptoExchange.Net.Sockets
             }
 
             var handledResponse = false;
-            foreach (var pendingRequest in pendingRequests.ToList())
+            PendingRequest[] requests;
+            lock(pendingRequests)
+			{
+                requests = pendingRequests.ToArray();
+			}
+            foreach (var pendingRequest in requests)
             {
                 if (pendingRequest.Check(tokenData))
                 {
-                    pendingRequests.Remove(pendingRequest);
+                    lock (pendingRequests)
+                    {
+                        pendingRequests.Remove(pendingRequest);
+                    }
                     if (pendingRequest.Result == null)
 					{
                         continue; // A previous timeout.
@@ -237,7 +245,10 @@ namespace CryptoExchange.Net.Sockets
         public virtual Task SendAndWait<T>(T obj, TimeSpan timeout, Func<JToken, bool> handler)
         {
             var pending = new PendingRequest(handler, timeout);
-            pendingRequests.Add(pending);
+            lock (pendingRequests)
+            {
+                pendingRequests.Add(pending);
+            }
             Send(obj);
             return pending.Event.WaitOneAsync(timeout);
         }


### PR DESCRIPTION
Fix for issue #71.
After removing the `pendingRequest,` the result is null only if it was remove on timeout. So the loop should continue to search for the appropriate `pendingRequest` handler.