### PR TITLE
Remove converter value mapping case insensitivity

### DIFF
--- a/CryptoExchange.Net/Converters/BaseConverter.cs
+++ b/CryptoExchange.Net/Converters/BaseConverter.cs
@@ -71,7 +71,7 @@ namespace CryptoExchange.Net.Converters
 
         private bool GetValue(string value, out T result)
         {
-            var mapping = Mapping.FirstOrDefault(kv => kv.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase));
+            var mapping = Mapping.FirstOrDefault(kv => kv.Value.Equals(value));
             if (!mapping.Equals(default(KeyValuePair<T, string>)))
             {
                 result = mapping.Key;

--- a/CryptoExchange.Net/Converters/BaseConverter.cs
+++ b/CryptoExchange.Net/Converters/BaseConverter.cs
@@ -71,7 +71,11 @@ namespace CryptoExchange.Net.Converters
 
         private bool GetValue(string value, out T result)
         {
-            var mapping = Mapping.FirstOrDefault(kv => kv.Value.Equals(value));
+            //check for exact match first, then if not found fallback to a case insensitive match 
+            var mapping = Mapping.FirstOrDefault(kv => kv.Value.Equals(value, StringComparison.InvariantCulture));
+            if(mapping.Equals(default(KeyValuePair<T, string>)))
+                mapping = Mapping.FirstOrDefault(kv => kv.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase));
+
             if (!mapping.Equals(default(KeyValuePair<T, string>)))
             {
                 result = mapping.Key;


### PR DESCRIPTION
Some mappers have multiple string identifiers with a variety of case.

An example of this is "_1m" and "_1M" in [KLIneIntervalConverter](https://github.com/JKorf/Binance.Net/blob/master/Binance.Net/Converters/KlineIntervalConverter.cs)

This PR removes the case insensitivity check while mapping the data in the BaseConverter.

Knock on impact from this might be significant, unsure how this would be tested.

Relates to https://github.com/JKorf/Binance.Net/issues/785
