### PR TITLE
change SetProxy method in web socket client to support socks5 proxy.

### DIFF
--- a/CryptoExchange.Net/Sockets/CryptoExchangeWebSocketClient.cs
+++ b/CryptoExchange.Net/Sockets/CryptoExchangeWebSocketClient.cs
@@ -212,9 +212,12 @@ namespace CryptoExchange.Net.Sockets
         /// <inheritdoc />
         public virtual void SetProxy(ApiProxy proxy)
         {
-            _socket.Options.Proxy = new WebProxy(proxy.Host, proxy.Port);
-            if (proxy.Login != null)
-                _socket.Options.Proxy.Credentials = new NetworkCredential(proxy.Login, proxy.Password);
+
+            _socket.Options.Proxy = new WebProxy
+            {
+                Address     = new Uri($"{proxy.Host}:{proxy.Port}"),
+                Credentials = proxy.Password == null ? null : new NetworkCredential(proxy.Login, proxy.Password)
+            };
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
SetProxy method in web socket currently uses this WebProxy constructor:

`      public WebProxy(string Host, int Port)
            : this(new Uri("http://" + Host + ":" + Port.ToString(CultureInfo.InvariantCulture)), false, null, null) {
        }`
[https://referencesource.microsoft.com/#System/net/System/Net/webproxy.cs,9381248d7627bd00](url)

which forces the proxy to use HTTP. so you can not use socks5 proxy. I changed this method to set the proxy as the same as BaseRestClient. ( Configure method in 
RequestFactory )
