### PR TITLE
Fixed: copying the port number when using a custom BaseAddress

### DIFF
--- a/CryptoExchange.Net/ExtensionMethods.cs
+++ b/CryptoExchange.Net/ExtensionMethods.cs
@@ -426,6 +426,7 @@ namespace CryptoExchange.Net
             var uriBuilder = new UriBuilder();
             uriBuilder.Scheme = baseUri.Scheme;
             uriBuilder.Host = baseUri.Host;
+            uriBuilder.Port = baseUri.Port;
             uriBuilder.Path = baseUri.AbsolutePath;
             var httpValueCollection = HttpUtility.ParseQueryString(string.Empty);
             foreach (var parameter in parameters)

--- a/CryptoExchange.Net/ExtensionMethods.cs
+++ b/CryptoExchange.Net/ExtensionMethods.cs
@@ -455,6 +455,7 @@ namespace CryptoExchange.Net
             var uriBuilder = new UriBuilder();
             uriBuilder.Scheme = baseUri.Scheme;
             uriBuilder.Host = baseUri.Host;
+            uriBuilder.Port = baseUri.Port;
             uriBuilder.Path = baseUri.AbsolutePath;
             var httpValueCollection = HttpUtility.ParseQueryString(string.Empty);
             foreach (var parameter in parameters)


### PR DESCRIPTION
When setting `BaseAddress` in `ApiClientOptions` it will successfully call  `ConstructRequest` with the correct Uri, after which, a call an extension method `SetParameters` copies the properties off the Uri into a new instance with the parameters included but unfortunately, it does not include the port number. This results in the port missing and and http/s request wont land. 

This fix adds copying the port number. 
