### PR TITLE
Fix for #146 parsing malformed json websocket data

### DIFF
--- a/CryptoExchange.Net/ExtensionMethods.cs
+++ b/CryptoExchange.Net/ExtensionMethods.cs
@@ -280,6 +280,19 @@ namespace CryptoExchange.Net
         }
 
         /// <summary>
+        /// String to JValue
+        /// </summary>
+        /// <param name="stringData"></param>
+        /// <returns>JValue</returns>
+        public static JValue? ToJValue(this string stringData)
+        {
+            if (string.IsNullOrEmpty(stringData))
+                return null;
+
+            return new JValue(stringData);
+        }
+
+        /// <summary>
         /// Validates an int is one of the allowed values
         /// </summary>
         /// <param name="value">Value of the int</param>

--- a/CryptoExchange.Net/Sockets/SocketConnection.cs
+++ b/CryptoExchange.Net/Sockets/SocketConnection.cs
@@ -449,8 +449,7 @@ namespace CryptoExchange.Net.Sockets
             var tokenData = data.ToJToken(log);
             if (tokenData == null)
             {
-                data = $"\"{data}\"";
-                tokenData = data.ToJToken(log);
+                tokenData = data.ToJValue();
                 if (tokenData == null)
                     return;
             }


### PR DESCRIPTION
This fixes issue #146 and makes the WebSocket ProcessMessage handle malformed json data.

The original code had a fallback, if it can't be parsed as JSON, add quotes around it and create a JSON object with the value as a single string from the result. I believe that is the intent.

I am keeping the same intent, but changed the code so that it explicitly creates a `JValue` string object from the result string. This causes malformed json strings as in issue #146 to be successfully parsed and returned as JToken.
