### PR TITLE
Make KeepAliveInterval nullable

### DIFF
--- a/CryptoExchange.Net/Clients/BaseSocketClient.cs
+++ b/CryptoExchange.Net/Clients/BaseSocketClient.cs
@@ -37,7 +37,7 @@ namespace CryptoExchange.Net
         /// <summary>
         /// Keep alive interval for websocket connection
         /// </summary>
-        protected TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(10);
+        protected TimeSpan? KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(10);
         /// <summary>
         /// Delegate used for processing byte data received from socket connections before it is processed by handlers
         /// </summary>


### PR DESCRIPTION
Some exchanges don't accept pinging from the client side. Make KeepAliveInternal nullable to disable client-side pinging