### PR TITLE
Add option to delay after connecting a socket

### DIFF
--- a/CryptoExchange.Net/Clients/BaseSocketClient.cs
+++ b/CryptoExchange.Net/Clients/BaseSocketClient.cs
@@ -389,6 +389,9 @@ namespace CryptoExchange.Net
             if (!connectResult)
                 return new CallResult<bool>(connectResult.Error!);
 
+            if (ClientOptions.DelayAfterConnect != TimeSpan.Zero)
+                await Task.Delay(ClientOptions.DelayAfterConnect).ConfigureAwait(false);
+
             if (!authenticated || socket.Authenticated)
                 return new CallResult<bool>(true);
 

--- a/CryptoExchange.Net/Objects/Options.cs
+++ b/CryptoExchange.Net/Objects/Options.cs
@@ -205,6 +205,11 @@ namespace CryptoExchange.Net.Objects
         public int? MaxSocketConnections { get; set; }
 
         /// <summary>
+        /// The time to wait after connecting a socket. Can be used for API's which will rate limit if you subscribe directly after connecting.
+        /// </summary>
+        public TimeSpan DelayAfterConnect = TimeSpan.Zero;
+
+        /// <summary>
         /// ctor
         /// </summary>
         public BaseSocketClientOptions(): this(null)


### PR DESCRIPTION
Some exchanges may rate limit you if sending a subscribe message shortly after connection. This option enables delaying a bit after connecting.