### PR TITLE
Add possibility to change rate limiters on the fly

### DIFF
--- a/CryptoExchange.Net/Objects/Options/RestApiOptions.cs
+++ b/CryptoExchange.Net/Objects/Options/RestApiOptions.cs
@@ -21,6 +21,11 @@ namespace CryptoExchange.Net.Objects.Options
         public RateLimitingBehaviour RateLimitingBehaviour { get; set; } = RateLimitingBehaviour.Wait;
 
         /// <summary>
+        /// Whether or not any further changes of RateLimiters or RateLimitingBehaviour impact RestApiClient behaviour
+        /// </summary>
+        public bool IsRateLimitReplacingAllowed { get; set; } = false;
+
+        /// <summary>
         /// Whether or not to automatically sync the local time with the server time
         /// </summary>
         public bool? AutoTimestamp { get; set; }
@@ -44,6 +49,7 @@ namespace CryptoExchange.Net.Objects.Options
                 AutoTimestamp = AutoTimestamp,
                 RateLimiters = RateLimiters,
                 RateLimitingBehaviour = RateLimitingBehaviour,
+                IsRateLimitReplacingAllowed = IsRateLimitReplacingAllowed,
                 TimestampRecalculationInterval = TimestampRecalculationInterval
             };
         }

--- a/docs/RateLimiter.md
+++ b/docs/RateLimiter.md
@@ -30,6 +30,18 @@ new RateLimiter()
             .AddEndpointLimit("/api/order", 10, TimeSpan.FromSeconds(2))
 ```
 This adds another limit of 10 requests per 2 seconds in addition to the 50 requests per 10 seconds limit.
+
+Also, you can change, add new or remove rate limiters from the `RestApiClient`, but only if you instantiate the client with `IsRateLimitReplacingAllowed = true` client API option:
+```csharp
+ApiOptions.RateLimiters.Clear();
+ApiOptions.RateLimiters.Add(
+        new RateLimiter()
+        .AddTotalRateLimit(300, TimeSpan.FromMinutes(1))
+        .AddPartialEndpointLimit("public/", 60, TimeSpan.FromMinutes(1), ignoreOtherRateLimits: true)
+);
+```
+This replaces current rate limiters with new one with two limits.
+
 These are the available rate limit configurations:
 
 ### AddTotalRateLimit


### PR DESCRIPTION
with `RestApiOptions.IsRateLimitReplacingAllowed = true` `RestApiClient` uses the same instance of `RateLimiters`
 as `RestApiOptions`, so changes in RestApiOptions will impact RestApiClient.
 The same with `RateLimitingBehaviour`.
 
 fixes JKorf/CryptoExchange.Net#179
 