### PR TITLE
Add feature to ignore only some unhandled messages

### DIFF
--- a/CryptoExchange.Net.UnitTests/SocketClientTests.cs
+++ b/CryptoExchange.Net.UnitTests/SocketClientTests.cs
@@ -245,10 +245,7 @@ namespace CryptoExchange.Net.UnitTests
             });
             var socket = client.CreateSocket();
             socket.CanConnect = true;
-            var connection = new SocketConnection(new TraceLogger(), client.SubClient, socket, "https://test.test");
-            client.SubClient.ConnectSocketSub(connection);
-            var subObj = new TestSubscription<Dictionary<string, string>>(Mock.Of<ILogger>(), messageEvent => { });
-            connection.AddSubscription(subObj);
+            var _ = client.SubClient.SubscribeToSomethingAsync("BTCUSD", onUpdate => { }, default);
 
             // act
             client.SubClient.IgnoredUnhandledMessages = new HashSet<string> { "connected" };

--- a/CryptoExchange.Net.UnitTests/TestImplementations/TestSocketClient.cs
+++ b/CryptoExchange.Net.UnitTests/TestImplementations/TestSocketClient.cs
@@ -13,6 +13,7 @@ using CryptoExchange.Net.Sockets;
 using CryptoExchange.Net.UnitTests.TestImplementations.Sockets;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace CryptoExchange.Net.UnitTests.TestImplementations
@@ -74,6 +75,7 @@ namespace CryptoExchange.Net.UnitTests.TestImplementations
 
     public class TestSubSocketClient : SocketApiClient
     {
+        public List<object> UnhandledMessages { get; } = new List<object>();
         private MessagePath _channelPath = MessagePath.Get().Property("channel");
         private MessagePath _topicPath = MessagePath.Get().Property("topic");
 
@@ -82,6 +84,18 @@ namespace CryptoExchange.Net.UnitTests.TestImplementations
         public TestSubSocketClient(TestSocketOptions options, SocketApiOptions apiOptions) : base(new TraceLogger(), options.Environment.TestAddress, options, apiOptions)
         {
 
+        }
+
+        protected override void HandleUnhandledMessage(IMessageAccessor message)
+        {
+            if (message.Underlying is JObject json)
+            {
+                UnhandledMessages.Add(json.ToString(Formatting.None));
+            }
+            else
+            {
+                UnhandledMessages.Add(message.Underlying);
+            }
         }
 
         internal IWebsocket CreateSocketInternal(string address)

--- a/CryptoExchange.Net/Clients/SocketApiClient.cs
+++ b/CryptoExchange.Net/Clients/SocketApiClient.cs
@@ -518,7 +518,6 @@ namespace CryptoExchange.Net.Clients
         {
             if (await socketConnection.ConnectAsync().ConfigureAwait(false))
             {
-                socketConnection.UnhandledMessage += HandleUnhandledMessage;
                 socketConnections.TryAdd(socketConnection.SocketId, socketConnection);
                 return new CallResult<bool>(true);
             }

--- a/CryptoExchange.Net/Clients/SocketApiClient.cs
+++ b/CryptoExchange.Net/Clients/SocketApiClient.cs
@@ -52,6 +52,11 @@ namespace CryptoExchange.Net.Clients
         protected internal bool UnhandledMessageExpected { get; set; }
 
         /// <summary>
+        /// To be used if <see cref="UnhandledMessageExpected"/> is false and some messages should be ignored
+        /// </summary>
+        protected internal HashSet<string>? IgnoredUnhandledMessages { get; set; } = null;
+
+        /// <summary>
         /// If true a subscription will accept message before the confirmation of a subscription has been received
         /// </summary>
         protected bool HandleMessageBeforeConfirmation { get; set; }
@@ -495,6 +500,16 @@ namespace CryptoExchange.Net.Clients
         }
 
         /// <summary>
+        /// Check if an unhandled message with the given listen id should be ignored
+        /// </summary>
+        /// <param name="listenId"></param>
+        /// <returns></returns>
+        public bool IsUnhandledMessageIgnored(string listenId)
+        {
+            return IgnoredUnhandledMessages?.Contains(listenId) ?? false;
+        }
+
+        /// <summary>
         /// Connect a socket
         /// </summary>
         /// <param name="socketConnection">The socket to connect</param>
@@ -503,6 +518,7 @@ namespace CryptoExchange.Net.Clients
         {
             if (await socketConnection.ConnectAsync().ConfigureAwait(false))
             {
+                socketConnection.UnhandledMessage += HandleUnhandledMessage;
                 socketConnections.TryAdd(socketConnection.SocketId, socketConnection);
                 return new CallResult<bool>(true);
             }

--- a/CryptoExchange.Net/Sockets/SocketConnection.cs
+++ b/CryptoExchange.Net/Sockets/SocketConnection.cs
@@ -404,7 +404,7 @@ namespace CryptoExchange.Net.Sockets
 
                 if (processors.Count == 0)
                 {
-                    if (!ApiClient.UnhandledMessageExpected)
+                    if (!ApiClient.UnhandledMessageExpected && !ApiClient.IsUnhandledMessageIgnored(listenId))
                     {
                         List<string> listenerIds;
                         lock (_listenersLock)


### PR DESCRIPTION
I think setting `UnhandledMessageExpected = true` may hide too many messages. Let's say the exchange sends some messages you don't want to handle and you need to enable UnhandledMessageExpected to avoid noise in the log.

By adding the property `HashSet<string>? IgnoredUnhandledMessages` in `SocketApiClient`, you can ignore a set of unhandled messages and log the messages that are not ignored.

I added a test case where a "connected" message is ignored and "unhandled" will be logged.