### PR TITLE
Get the state of ApiClient, SocketConnection, and Subscription as a record

### DIFF
--- a/CryptoExchange.Net/Clients/BaseSocketClient.cs
+++ b/CryptoExchange.Net/Clients/BaseSocketClient.cs
@@ -108,5 +108,19 @@ namespace CryptoExchange.Net.Clients
             }
             return result.ToString();
         }
+
+        /// <summary>
+        /// Returns the state of all socket api clients
+        /// </summary>
+        /// <returns></returns>
+        public List<SocketApiClient.SocketApiClientState> GetSocketApiClientStates()
+        {
+            var result = new List<SocketApiClient.SocketApiClientState>();
+            foreach (var client in ApiClients.OfType<SocketApiClient>())
+            {
+                result.Add(client.GetState());
+            }
+            return result;
+        }
     }
 }

--- a/CryptoExchange.Net/Sockets/Subscription.cs
+++ b/CryptoExchange.Net/Sockets/Subscription.cs
@@ -156,6 +156,29 @@ namespace CryptoExchange.Net.Sockets
         {
             Exception?.Invoke(e);
         }
+
+        /// <summary>
+        /// State of this subscription
+        /// </summary>
+        /// <param name="Id">The id of the subscription</param>
+        /// <param name="Confirmed">True when the subscription query is handled (either accepted or rejected)</param>
+        /// <param name="Invocations">Number of times this subscription got a message</param>
+        /// <param name="Identifiers">Identifiers the subscription is listening to</param>
+        public record SubscriptionState(
+            int Id,
+            bool Confirmed,
+            int Invocations,
+            HashSet<string> Identifiers
+        );
+
+        /// <summary>
+        /// Get the state of this subscription
+        /// </summary>
+        /// <returns></returns>
+        public SubscriptionState GetState()
+        {
+            return new SubscriptionState(Id, Confirmed, TotalInvocations, ListenerIdentifiers);
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
### Feature
Get api socket client state as a `record` to easily analyze the state of the client, connection, and subscriptions.
The existing string status message is not easy to reuse or parse to display in a different way

- Add `BaseSocketClient.GetSocketApiClientStates` to get `SocketApiClientState` for each `SocketApiClient`
- Override `PrintMembers` of the record to preserve `string GetSubscriptionsState` functionality

