### PR TITLE
Avoid returning null from ProcessAsync and ProcessSingleAsync

### DIFF
--- a/CryptoExchange.Net/Clients/RestApiClient.cs
+++ b/CryptoExchange.Net/Clients/RestApiClient.cs
@@ -305,7 +305,7 @@ namespace CryptoExchange.Net.Clients
                 {
                     var limitResult = await definition.RateLimitGate.ProcessAsync(_logger, requestId, RateLimitItemType.Request, definition, baseAddress, AuthenticationProvider?._credentials.Key, requestWeight, ClientOptions.RateLimitingBehaviour, cancellationToken).ConfigureAwait(false);
                     if (!limitResult)
-                        return new CallResult(limitResult.Error!);
+                        return new CallResult(limitResult?.Error ?? new UnknownError("ProcessAsync failed"));
                 }
             }
 
@@ -319,7 +319,7 @@ namespace CryptoExchange.Net.Clients
                 {
                     var limitResult = await definition.RateLimitGate.ProcessSingleAsync(_logger, requestId, definition.LimitGuard, RateLimitItemType.Request, definition, baseAddress, AuthenticationProvider?._credentials.Key, ClientOptions.RateLimitingBehaviour, cancellationToken).ConfigureAwait(false);
                     if (!limitResult)
-                        return new CallResult(limitResult.Error!);
+                        return new CallResult(limitResult?.Error ?? new UnknownError("ProcessSingleAsync failed"));
                 }
             }
 

--- a/CryptoExchange.Net/RateLimiting/RateLimitGate.cs
+++ b/CryptoExchange.Net/RateLimiting/RateLimitGate.cs
@@ -49,7 +49,11 @@ namespace CryptoExchange.Net.RateLimiting
             {
                 // The semaphore has alraedy been released if the task was cancelled
                 release = false;
-                throw;
+                return new CallResult(new CancellationRequestedError());
+            }
+            catch (Exception e)
+            {
+                return new CallResult(new UnknownError(e.Message));
             }
             finally
             {
@@ -82,7 +86,11 @@ namespace CryptoExchange.Net.RateLimiting
             {
                 // The semaphore has alraedy been released if the task was cancelled
                 release = false;
-                throw;
+                return new CallResult(new CancellationRequestedError());
+            }
+            catch (Exception e)
+            {
+                return new CallResult(new UnknownError(e.Message));
             }
             finally
             {

--- a/CryptoExchange.Net/Sockets/CryptoExchangeWebSocketClient.cs
+++ b/CryptoExchange.Net/Sockets/CryptoExchangeWebSocketClient.cs
@@ -206,7 +206,7 @@ namespace CryptoExchange.Net.Sockets
                     var definition = new RequestDefinition(Id.ToString(), HttpMethod.Get);
                     var limitResult = await Parameters.RateLimiter.ProcessAsync(_logger, Id, RateLimitItemType.Connection, definition, _baseAddress, null, 1, Parameters.RateLimitingBehaviour, _ctsSource.Token).ConfigureAwait(false);
                     if (!limitResult)
-                        return new CallResult(new ClientRateLimitError("Connection limit reached"));
+                        return new CallResult(limitResult?.Error ?? new ClientRateLimitError("Connection limit reached"));
                 }
 
                 using CancellationTokenSource tcs = new(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
try-finally may(will?) return null when an exception occurs. Won't that be an issue when consuming the result using `limitResult.Error!`?