### PR TITLE
feature: Handle error 429 when connecting websocket

### DIFF
--- a/CryptoExchange.Net/Interfaces/IWebsocket.cs
+++ b/CryptoExchange.Net/Interfaces/IWebsocket.cs
@@ -27,6 +27,10 @@ namespace CryptoExchange.Net.Interfaces
         /// </summary>
         event Func<int, Task>? OnRequestRateLimited;
         /// <summary>
+        /// Connection was ratelimited and couldn't be established
+        /// </summary>
+        event Func<Task>? OnConnectRateLimited;
+        /// <summary>
         /// Websocket error event
         /// </summary>
         event Func<Exception, Task> OnError;

--- a/CryptoExchange.Net/Logging/Extensions/SocketApiClientLoggingExtension.cs
+++ b/CryptoExchange.Net/Logging/Extensions/SocketApiClientLoggingExtension.cs
@@ -22,6 +22,7 @@ namespace CryptoExchange.Net.Logging.Extensions
         private static readonly Action<ILogger, Exception?> _disposingSocketClient;
         private static readonly Action<ILogger, int, int, Exception?> _unsubscribingSubscription;
         private static readonly Action<ILogger, int, Exception?> _reconnectingAllConnections;
+        private static readonly Action<ILogger, DateTime, Exception?> _addingRetryAfterGuard;
 
         static SocketApiClientLoggingExtension()
         {
@@ -104,6 +105,11 @@ namespace CryptoExchange.Net.Logging.Extensions
                 LogLevel.Information,
                 new EventId(3017, "ReconnectingAll"),
                 "Reconnecting all {ConnectionCount} connections");
+
+            _addingRetryAfterGuard = LoggerMessage.Define<DateTime>(
+                LogLevel.Warning,
+                new EventId(3018, "AddRetryAfterGuard"),
+                "Adding RetryAfterGuard ({RetryAfter}) because the connection attempt was rate limited");
         }
 
         public static void FailedToAddSubscriptionRetryOnDifferentConnection(this ILogger logger, int socketId)
@@ -184,6 +190,11 @@ namespace CryptoExchange.Net.Logging.Extensions
         public static void ReconnectingAllConnections(this ILogger logger, int connectionCount)
         {
             _reconnectingAllConnections(logger, connectionCount, null);
+        }
+
+        public static void AddingRetryAfterGuard(this ILogger logger, DateTime retryAfter)
+        {
+            _addingRetryAfterGuard(logger, retryAfter, null);
         }
     }
 }

--- a/CryptoExchange.Net/Objects/Options/SocketExchangeOptions.cs
+++ b/CryptoExchange.Net/Objects/Options/SocketExchangeOptions.cs
@@ -48,6 +48,12 @@ namespace CryptoExchange.Net.Objects.Options
         public TimeSpan DelayAfterConnect { get; set; } = TimeSpan.Zero;
 
         /// <summary>
+        /// This delay is used to set a RetryAfter guard on the connection after a rate limit is hit on the server. 
+        /// This is used to prevent the client from reconnecting too quickly after a rate limit is hit.
+        /// </summary>
+        public TimeSpan? ConnectDelayAfterRateLimited { get; set; }
+
+        /// <summary>
         /// Create a copy of this options
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/CryptoExchange.Net/RateLimiting/Guards/RetryAfterGuard.cs
+++ b/CryptoExchange.Net/RateLimiting/Guards/RetryAfterGuard.cs
@@ -21,7 +21,7 @@ namespace CryptoExchange.Net.RateLimiting.Guards
         public string Name => "RetryAfterGuard";
 
         /// <inheritdoc />
-        public string Description => $"Pause requests until after {After}";
+        public string Description => $"Pause {Type} until after {After}";
 
         /// <summary>
         /// The timestamp after which requests are allowed again
@@ -29,17 +29,27 @@ namespace CryptoExchange.Net.RateLimiting.Guards
         public DateTime After { get; private set; }
 
         /// <summary>
+        /// The type of rate limit item this guard is for
+        /// </summary>
+        public RateLimitItemType Type { get; private set; }
+
+        /// <summary>
         /// ctor
         /// </summary>
         /// <param name="after"></param>
-        public RetryAfterGuard(DateTime after)
+        /// <param name="type"></param>
+        public RetryAfterGuard(DateTime after, RateLimitItemType type)
         {
             After = after;
+            Type = type;
         }
 
         /// <inheritdoc />
         public LimitCheck Check(RateLimitItemType type, RequestDefinition definition, string host, string? apiKey, int requestWeight)
         {
+            if (type != Type)
+                return LimitCheck.NotApplicable;
+
             var dif = (After + _windowBuffer) - DateTime.UtcNow;
             if (dif <= TimeSpan.Zero)
                 return LimitCheck.NotApplicable;

--- a/CryptoExchange.Net/RateLimiting/Interfaces/IRateLimitGate.cs
+++ b/CryptoExchange.Net/RateLimiting/Interfaces/IRateLimitGate.cs
@@ -29,8 +29,9 @@ namespace CryptoExchange.Net.RateLimiting.Interfaces
         /// Set a RetryAfter guard, can be used when a server rate limit is hit and a RetryAfter header is specified
         /// </summary>
         /// <param name="retryAfter">The time after which requests can be send again</param>
+        /// <param name="type">RateLimitType</param>
         /// <returns></returns>
-        Task SetRetryAfterGuardAsync(DateTime retryAfter);
+        Task SetRetryAfterGuardAsync(DateTime retryAfter, RateLimitItemType type = RateLimitItemType.Request);
 
         /// <summary>
         /// Returns the 'retry after' timestamp if set

--- a/CryptoExchange.Net/RateLimiting/RateLimitGate.cs
+++ b/CryptoExchange.Net/RateLimiting/RateLimitGate.cs
@@ -152,7 +152,7 @@ namespace CryptoExchange.Net.RateLimiting
         }
 
         /// <inheritdoc />
-        public async Task SetRetryAfterGuardAsync(DateTime retryAfter)
+        public async Task SetRetryAfterGuardAsync(DateTime retryAfter, RateLimitItemType type)
         {
             await _semaphore.WaitAsync().ConfigureAwait(false);
 
@@ -160,7 +160,7 @@ namespace CryptoExchange.Net.RateLimiting
             {
                 var retryAfterGuard = _guards.OfType<RetryAfterGuard>().SingleOrDefault();
                 if (retryAfterGuard == null)
-                    _guards.Add(new RetryAfterGuard(retryAfter));
+                    _guards.Add(new RetryAfterGuard(retryAfter, type));
                 else
                     retryAfterGuard.UpdateAfter(retryAfter);
             }

--- a/CryptoExchange.Net/Sockets/CryptoExchangeWebSocketClient.cs
+++ b/CryptoExchange.Net/Sockets/CryptoExchangeWebSocketClient.cs
@@ -189,6 +189,9 @@ namespace CryptoExchange.Net.Sockets
                     socket.Options.SetBuffer(_receiveBufferSize, _sendBufferSize);
                 if (Parameters.Proxy != null)
                     SetProxy(socket, Parameters.Proxy);
+                #if NET6_0_OR_GREATER
+                socket.Options.CollectHttpResponseDetails = true;
+                #endif
             }
             catch (PlatformNotSupportedException)
             {
@@ -226,6 +229,13 @@ namespace CryptoExchange.Net.Sockets
 
                 if (e is WebSocketException we)
                 {
+                    #if (NET6_0_OR_GREATER)
+                    if (_socket.HttpStatusCode == HttpStatusCode.TooManyRequests)
+                    {
+                        await (OnConnectRateLimited?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
+                        return new CallResult(new ServerRateLimitError(we.Message));
+                    }
+                    #else
                     // ClientWebSocket.HttpStatusCode is only available in .NET6+ https://learn.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocket.httpstatuscode?view=net-8.0
                     // Try to read 429 from the message instead
                     if (we.Message.Contains("429"))
@@ -233,6 +243,7 @@ namespace CryptoExchange.Net.Sockets
                         await (OnConnectRateLimited?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
                         return new CallResult(new ServerRateLimitError(we.Message));
                     }
+                    #endif
                 }
 
                 return new CallResult(new CantConnectError());

--- a/CryptoExchange.Net/Sockets/SocketConnection.cs
+++ b/CryptoExchange.Net/Sockets/SocketConnection.cs
@@ -72,6 +72,11 @@ namespace CryptoExchange.Net.Sockets
         public event Action<IMessageAccessor>? UnhandledMessage;
 
         /// <summary>
+        /// Connection was rate limited and couldn't be established
+        /// </summary>
+        public Func<Task>? ConnectRateLimitedAsync;
+
+        /// <summary>
         /// The amount of subscriptions on this connection
         /// </summary>
         public int UserSubscriptionCount
@@ -222,6 +227,7 @@ namespace CryptoExchange.Net.Sockets
             _socket.OnStreamMessage += HandleStreamMessage;
             _socket.OnRequestSent += HandleRequestSentAsync;
             _socket.OnRequestRateLimited += HandleRequestRateLimitedAsync;
+            _socket.OnConnectRateLimited += HandleConnectRateLimitedAsync;
             _socket.OnOpen += HandleOpenAsync;
             _socket.OnClose += HandleCloseAsync;
             _socket.OnReconnecting += HandleReconnectingAsync;
@@ -383,6 +389,16 @@ namespace CryptoExchange.Net.Sockets
 
             query.Fail(new ClientRateLimitError("Connection rate limit reached"));
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Handler for whenever a connection was rate limited and couldn't be established
+        /// </summary>
+        /// <returns></returns>
+        protected async virtual Task HandleConnectRateLimitedAsync()
+        {
+             if (ConnectRateLimitedAsync is not null)
+                await ConnectRateLimitedAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/CryptoExchange.Net/Testing/Implementations/TestSocket.cs
+++ b/CryptoExchange.Net/Testing/Implementations/TestSocket.cs
@@ -20,6 +20,7 @@ namespace CryptoExchange.Net.Testing.Implementations
         public event Func<Task>? OnReconnected;
         public event Func<Task>? OnReconnecting;
         public event Func<int, Task>? OnRequestRateLimited;
+        public event Func<Task>? OnConnectRateLimited;
         public event Func<Exception, Task>? OnError;
 #pragma warning restore 0067
         public event Func<int, Task>? OnRequestSent;


### PR DESCRIPTION
A RateLimitGuard can be used to limit (re)connection of sockets.
This works well until the server returns 429 and the client continues to use the configured client rate limit.
If the client is too eager to reconnect, the client may be stuck in a 429 rate limit loop.

This feature enables setting `SocketExchangeOptions.ConnectDelayAfterRateLimited` which will set a `RetryAfterGuard`on the connection when the server returns 429.

- Parse error message thrown from `ClientWebSocket.Connect` when connecting the socket fails
    - Check if "429" is in the error message
- Add `RateLimitItemType` to RetryAfterGuard
-  Add `SocketExchangeOptions.ConnectDelayAfterRateLimited`
    -  Works as a one-time rate limit to avoid subsequent connection attempts that pass the regular connection rate limiting

Note: I could not create a unit test for this behavior.