### PR TITLE
Fixed ArrrayConverter serialization of nullable types

### DIFF
--- a/CryptoExchange.Net/Converters/SystemTextJson/ArrayConverter.cs
+++ b/CryptoExchange.Net/Converters/SystemTextJson/ArrayConverter.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using CryptoExchange.Net.Attributes;
-using System.Collections.Generic;
 
 namespace CryptoExchange.Net.Converters.SystemTextJson
 {
@@ -87,11 +87,12 @@ namespace CryptoExchange.Net.Converters.SystemTextJson
 
                     if (prop.JsonConverterType == null && IsSimple(prop.PropertyInfo.PropertyType))
                     {
-                        if (prop.PropertyInfo.PropertyType == typeof(string))
+                        var realType = Nullable.GetUnderlyingType(prop.PropertyInfo.PropertyType) ?? prop.PropertyInfo.PropertyType;
+                        if (realType == typeof(string))
                             writer.WriteStringValue(Convert.ToString(objValue, CultureInfo.InvariantCulture));
-                        else if(prop.PropertyInfo.PropertyType.IsEnum)
+                        else if (realType.IsEnum)
                             writer.WriteStringValue(EnumConverter.GetString(objValue));
-                        else if (prop.PropertyInfo.PropertyType == typeof(bool))
+                        else if (realType == typeof(bool))
                             writer.WriteBooleanValue((bool)objValue);
                         else
                             writer.WriteRawValue(Convert.ToString(objValue, CultureInfo.InvariantCulture)!);


### PR DESCRIPTION
Fixed an error I encountered when trying to serialise the `Nullable<bool>` property `BitfinexTradeDetails.Maker`.

```
  System.Text.Json.JsonReaderException: 'T' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0.
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.ConsumeValue(Byte marker)
   at System.Text.Json.Utf8JsonReader.ReadFirstToken(Byte first)
   at System.Text.Json.Utf8JsonReader.ReadSingleSegment()
   at System.Text.Json.Utf8JsonReader.Read()
   at System.Text.Json.Utf8JsonWriter.WriteRawValueCore(ReadOnlySpan`1 utf8Json, Boolean skipInputValidation)
   at System.Text.Json.Utf8JsonWriter.TranscodeAndWriteRawValue(ReadOnlySpan`1 json, Boolean skipInputValidation)
   at System.Text.Json.Utf8JsonWriter.WriteRawValue(String json, Boolean skipInputValidation)
   at CryptoExchange.Net.Converters.SystemTextJson.ArrayConverter.ArrayConverterInner`1.Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) in C:\Dev\CryptoExchangeNet\CryptoExchange.Net\CryptoExchange.Net\Converters\SystemTextJson\ArrayConverter.cs:line 97
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.WriteCore(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Serialize(Utf8JsonWriter writer, T& rootValue, Object rootValueBoxed)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.SerializeAsObject(Utf8JsonWriter writer, Object rootValue)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Serialize(Utf8JsonWriter writer, T& rootValue, Object rootValueBoxed)
   at System.Text.Json.JsonSerializer.WriteString[TValue](TValue& value, JsonTypeInfo`1 jsonTypeInfo)
   at System.Text.Json.JsonSerializer.Serialize[TValue](TValue value, JsonSerializerOptions options)
```