### PR TITLE
Allow specifying the ReceiveMessageBuffer size on Websockets

### DIFF
--- a/CryptoExchange.Net/Clients/SocketApiClient.cs
+++ b/CryptoExchange.Net/Clients/SocketApiClient.cs
@@ -600,7 +600,8 @@ namespace CryptoExchange.Net.Clients
                 RateLimiter = ClientOptions.RateLimiterEnabled ? RateLimiter : null,
                 RateLimitingBehavior = ClientOptions.RateLimitingBehaviour,
                 Proxy = ClientOptions.Proxy,
-                Timeout = ApiOptions.SocketNoDataTimeout ?? ClientOptions.SocketNoDataTimeout
+                Timeout = ApiOptions.SocketNoDataTimeout ?? ClientOptions.SocketNoDataTimeout,
+                ReceiveBufferSize = ClientOptions.ReceiveBufferSize,
             };
 
         /// <summary>

--- a/CryptoExchange.Net/Objects/Options/SocketExchangeOptions.cs
+++ b/CryptoExchange.Net/Objects/Options/SocketExchangeOptions.cs
@@ -53,6 +53,15 @@ namespace CryptoExchange.Net.Objects.Options
         public TimeSpan? ConnectDelayAfterRateLimited { get; set; }
 
         /// <summary>
+        /// The buffer size to use for receiving data. Leave unset to use the default buffer size.
+        /// </summary>
+        /// <remarks>
+        /// Only specify this if you are creating a significant amount of connections and understand the typical message length we receive from the exchange.
+        /// Setting this too low can increase memory consumption and allocations.
+        /// </remarks>
+        public int? ReceiveBufferSize { get; set; }
+
+        /// <summary>
         /// Create a copy of this options
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -72,6 +81,7 @@ namespace CryptoExchange.Net.Objects.Options
             item.RequestTimeout = RequestTimeout;
             item.RateLimitingBehaviour = RateLimitingBehaviour;
             item.RateLimiterEnabled = RateLimiterEnabled;
+            item.ReceiveBufferSize = ReceiveBufferSize;
             return item;
         }
     }

--- a/CryptoExchange.Net/Objects/Sockets/WebSocketParameters.cs
+++ b/CryptoExchange.Net/Objects/Sockets/WebSocketParameters.cs
@@ -65,6 +65,11 @@ namespace CryptoExchange.Net.Objects.Sockets
         public Encoding Encoding { get; set; } = Encoding.UTF8;
 
         /// <summary>
+        /// The buffer size to use for receiving data
+        /// </summary>
+        public int? ReceiveBufferSize { get; set; } = null;
+
+        /// <summary>
         /// ctor
         /// </summary>
         /// <param name="uri">Uri</param>


### PR DESCRIPTION
In order to support more User websocket connections, allow reducing the memory requirements for the receive buffer size, keeping the default buffer for when no customisation is desired.

I also moved the ReceiveBuffer to come from `ArrayPool.Shared`, but if you do not want this change, let me know and I can roll it back.