### PR TITLE
Fix memory leak in AsyncAutoResetEvent

### DIFF
--- a/CryptoExchange.Net.UnitTests/AsyncResetEventTests.cs
+++ b/CryptoExchange.Net.UnitTests/AsyncResetEventTests.cs
@@ -106,6 +106,7 @@ namespace CryptoExchange.Net.UnitTests
             for(var i = 1; i <= 10; i++)
             {
                 evnt.Set();
+                await Task.Delay(1); // Wait for the continuation.
                 Assert.That(10 - i == waiters.Count(w => w.Status != TaskStatus.RanToCompletion));
             }
 


### PR DESCRIPTION
CancellationTokenRegistration MUST be disposed, as the CancellationToken passed is saved for the lifetime of the Client, and registrations build up forever.

Sorry for what looks like a messy commit, due to indention from the try/finally.

The problem is, because we are using a cached `_ctsSource` when calling your `AsyncAutoResetEvent`, without a Timeout (in `SendLoopAsync` and other places), it doesnt generate a new CancellationTokenSource every time, meaning the Registrations you create are not removed from the token.

This means we continue to add CallbackNodes to the `_ctsSource` forever. The other option is ALWAYS creating a new LinkedToken in `WaitAsync`, but instead I opted to dispose of the `CancellationTokenRegistration` you create.

This does mean actually awaiting in this method, which it looks like you wanted to avoid, so if you like, you can instead create a new CancellationToken regardless of if there is a timeout specified or not, up to you!

I've been meaning to track this one down for a while, it only really becomes noticable once you have about 100 or so clients connected.