### PR TITLE
Create default RateLimitGate if null in HandleConnectRateLimitedAsync

### DIFF
--- a/CryptoExchange.Net/Clients/SocketApiClient.cs
+++ b/CryptoExchange.Net/Clients/SocketApiClient.cs
@@ -3,6 +3,7 @@ using CryptoExchange.Net.Logging.Extensions;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Options;
 using CryptoExchange.Net.Objects.Sockets;
+using CryptoExchange.Net.RateLimiting;
 using CryptoExchange.Net.RateLimiting.Interfaces;
 using CryptoExchange.Net.Sockets;
 using Microsoft.Extensions.Logging;
@@ -565,11 +566,12 @@ namespace CryptoExchange.Net.Clients
         /// </summary>
         protected async virtual Task HandleConnectRateLimitedAsync()
         {
-            if (ClientOptions.RateLimiterEnabled && RateLimiter is not null && ClientOptions.ConnectDelayAfterRateLimited is not null)
+            if (ClientOptions.RateLimiterEnabled && ClientOptions.ConnectDelayAfterRateLimited.HasValue)
             {
                 var retryAfter = DateTime.UtcNow.Add(ClientOptions.ConnectDelayAfterRateLimited.Value);
                 _logger.AddingRetryAfterGuard(retryAfter);
-                await RateLimiter.SetRetryAfterGuardAsync(retryAfter, RateLimiting.RateLimitItemType.Connection).ConfigureAwait(false);
+                RateLimiter ??= new RateLimitGate("Connection");
+                await RateLimiter.SetRetryAfterGuardAsync(retryAfter, RateLimitItemType.Connection).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
If a client has RateLimiterEnabled but no RateLimiter instance, it won't rate limit the connection. 

This patch will create a default RateLimitGate called "Connection" to enable connection rate limiting even if the socket api client doesn't have any RateLimiter instance already