### PR TITLE
PoC EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+﻿root = true
+
+[*]
+
+# Indentation and spacing
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+charset = utf-8
+max_line_length = 140
+insert_final_newline = true
+
+# ReSharper properties
+resharper_csharp_keep_existing_embedded_arrangement = false
+resharper_csharp_place_accessorholder_attribute_on_same_line = false
+resharper_csharp_wrap_after_declaration_lpar = true
+resharper_csharp_wrap_parameters_style = chop_if_long
+resharper_csharp_blank_lines_around_single_line_auto_property = 1
+resharper_csharp_keep_blank_lines_in_declarations = 1
+
+[*.cs]
+
+indent_size = 4
+
+# Code style conventions
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_prefer_braces = when_multiline:warning
+
+# Analyzer preferences
+dotnet_diagnostic.CA2007.severity = warning # Call ConfigureAwait on the awaited Task.
+dotnet_code_quality.CA2007.exclude_async_void_methods = true
+dotnet_code_quality.CA2007.output_kind = DynamicallyLinkedLibrary
+
+[*.xml]
+ij_xml_space_inside_empty_tag = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿root = true
+root = true
 
 [*]
 
@@ -29,6 +29,7 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_object_initializer = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_namespace_declarations = file_scoped:warning
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
@@ -43,7 +44,7 @@ dotnet_code_quality.CA2007.output_kind = DynamicallyLinkedLibrary
 dotnet_diagnostic.CA1720.severity = none # Identifiers should not contain type names
 dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types
 
-dotnet_diagnostic.IDE0055.severity = warning # Using directive is unnecessary
+dotnet_diagnostic.IDE0005.severity = warning # Using directive is unnecessary
 
 [*.xml]
 ij_xml_space_inside_empty_tag = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,13 +10,14 @@ charset = utf-8
 max_line_length = 140
 insert_final_newline = true
 
-# ReSharper properties
+# ReSharper code style properties
 resharper_csharp_keep_existing_embedded_arrangement = false
 resharper_csharp_place_accessorholder_attribute_on_same_line = false
 resharper_csharp_wrap_after_declaration_lpar = true
 resharper_csharp_wrap_parameters_style = chop_if_long
 resharper_csharp_blank_lines_around_single_line_auto_property = 1
 resharper_csharp_keep_blank_lines_in_declarations = 1
+resharper_trailing_comma_in_multiline_lists = true
 
 [*.cs]
 
@@ -28,12 +29,21 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_object_initializer = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_expression_bodied_methods = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 csharp_prefer_braces = when_multiline:warning
 
 # Analyzer preferences
 dotnet_diagnostic.CA2007.severity = warning # Call ConfigureAwait on the awaited Task.
 dotnet_code_quality.CA2007.exclude_async_void_methods = true
 dotnet_code_quality.CA2007.output_kind = DynamicallyLinkedLibrary
+
+dotnet_diagnostic.CA1720.severity = none # Identifiers should not contain type names
+dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types
+
+dotnet_diagnostic.IDE0055.severity = warning # Using directive is unnecessary
 
 [*.xml]
 ij_xml_space_inside_empty_tag = true

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -43,6 +43,7 @@
   <PropertyGroup>
     <AnalysisMode>Recommended</AnalysisMode>
     <AnalysisModeGlobalization>None</AnalysisModeGlobalization>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -51,4 +51,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
+  <ItemGroup Label="Transitive Client Packages">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
+  </ItemGroup>
 </Project>

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -19,9 +19,10 @@
     <PackageIcon>icon.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>https://github.com/JKorf/CryptoExchange.Net?tab=readme-ov-file#release-notes</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <None Include="Icon\icon.png" Pack="true" PackagePath="\" />

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -27,7 +27,7 @@
     <None Include="Icon\icon.png" Pack="true" PackagePath="\" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-  <PropertyGroup Label="AOT" Condition=" '$(TargetFramework)' == 'NET8_0' Or '$(TargetFramework)' == 'NET9_0' ">
+  <PropertyGroup Label="AOT" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup Label="Deterministic Build" Condition="'$(Configuration)' == 'Release'">

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -42,6 +42,7 @@
     <DocumentationFile>CryptoExchange.Net.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>Recommended</AnalysisMode>
     <AnalysisModeGlobalization>None</AnalysisModeGlobalization>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -37,30 +37,11 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  <ItemGroup Label="Deterministic Build" Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
   <PropertyGroup>
     <DocumentationFile>CryptoExchange.Net.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -40,6 +40,10 @@
   <PropertyGroup>
     <DocumentationFile>CryptoExchange.Net.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisModeGlobalization>None</AnalysisModeGlobalization>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />

--- a/CryptoExchange.Net/CryptoExchange.Net.csproj
+++ b/CryptoExchange.Net/CryptoExchange.Net.csproj
@@ -45,7 +45,7 @@
     <AnalysisModeGlobalization>None</AnalysisModeGlobalization>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The initiative raised within this PR is to lay the groundwork for enabling a consistent and comprehensive set of analyser rules across the project and further distribute them to other projects. With the addition of `.editorconfig` and configuring the project file, consistent coding standards are enforced automatically, helping keep the codebase clean and making code reviews more focused on logic rather than style issues.

Recent versions of .NET introduced several space-saving features like file-scoped namespaces and implicit usings, which have significantly improved code readability. This PR aligns the formatting rules to encourage the use of such modern practices.

The current version of .editorconfig contains some custom rules based on an analysis of the current codebase. However, it's a subject to discuss and change if needed.