### PR TITLE
Fixed EnumConverter to allow mapping empty string values

### DIFF
--- a/CryptoExchange.Net/Converters/SystemTextJson/EnumConverter.cs
+++ b/CryptoExchange.Net/Converters/SystemTextJson/EnumConverter.cs
@@ -140,10 +140,10 @@ namespace CryptoExchange.Net.Converters.SystemTextJson
                 _ => throw new Exception("Invalid token type for enum deserialization: " + reader.TokenType)
             };
 
-            if (string.IsNullOrEmpty(stringValue))
+            if (stringValue is null)
                 return null;
 
-            if (!GetValue(enumType, stringValue!, out var result))
+            if (!GetValue(enumType, stringValue, out var result))
             {
                 if (string.IsNullOrWhiteSpace(stringValue))
                 {


### PR DESCRIPTION
Updated the EnumConverter to allow mapping empty ("") string values to a specific enum value.
One example enum where I noticed the incorrect mapping was the `Bybit.Net.Enums.Category` enum.

*Btw*: Currently, there is no logging in a live system when an invalid enum value is trying to be mapped. All messages are currently only written via `Trace.WriteLine`. Since the default value is set in these cases, invalid data occurs unnoticed.