### PR TITLE
Pass CancellationToken to Content.ReadAsStreamAsync

### DIFF
--- a/CryptoExchange.Net.UnitTests/TestImplementations/TestRestClient.cs
+++ b/CryptoExchange.Net.UnitTests/TestImplementations/TestRestClient.cs
@@ -49,7 +49,7 @@ namespace CryptoExchange.Net.UnitTests.TestImplementations
 
             var response = new Mock<IResponse>();
             response.Setup(c => c.IsSuccessStatusCode).Returns(true);
-            response.Setup(c => c.GetResponseStreamAsync()).Returns(Task.FromResult((Stream)responseStream));
+            response.Setup(c => c.GetResponseStreamAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult((Stream)responseStream));
             
             var headers = new Dictionary<string, string[]>();
             var request = new Mock<IRequest>();
@@ -108,7 +108,7 @@ namespace CryptoExchange.Net.UnitTests.TestImplementations
 
             var response = new Mock<IResponse>();
             response.Setup(c => c.IsSuccessStatusCode).Returns(false);
-            response.Setup(c => c.GetResponseStreamAsync()).Returns(Task.FromResult((Stream)responseStream));
+            response.Setup(c => c.GetResponseStreamAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult((Stream)responseStream));
 
             var headers = new List<KeyValuePair<string, string[]>>();
             var request = new Mock<IRequest>();

--- a/CryptoExchange.Net/Clients/RestApiClient.cs
+++ b/CryptoExchange.Net/Clients/RestApiClient.cs
@@ -443,7 +443,7 @@ namespace CryptoExchange.Net.Clients
             {
                 response = await request.GetResponseAsync(cancellationToken).ConfigureAwait(false);
                 sw.Stop();
-                responseStream = await response.GetResponseStreamAsync().ConfigureAwait(false);
+                responseStream = await response.GetResponseStreamAsync(cancellationToken).ConfigureAwait(false);
                 var outputOriginalData = ApiOptions.OutputOriginalData ?? ClientOptions.OutputOriginalData;
 
                 accessor = CreateAccessor();

--- a/CryptoExchange.Net/Interfaces/IResponse.cs
+++ b/CryptoExchange.Net/Interfaces/IResponse.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CryptoExchange.Net.Interfaces
@@ -40,7 +41,7 @@ namespace CryptoExchange.Net.Interfaces
         /// Get the response stream
         /// </summary>
         /// <returns></returns>
-        Task<Stream> GetResponseStreamAsync();
+        Task<Stream> GetResponseStreamAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Close the response

--- a/CryptoExchange.Net/Requests/Response.cs
+++ b/CryptoExchange.Net/Requests/Response.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿using CryptoExchange.Net.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
-using CryptoExchange.Net.Interfaces;
 
 namespace CryptoExchange.Net.Requests
 {
@@ -41,9 +42,13 @@ namespace CryptoExchange.Net.Requests
         }
 
         /// <inheritdoc />
-        public async Task<Stream> GetResponseStreamAsync()
+        public async Task<Stream> GetResponseStreamAsync(CancellationToken cancellationToken)
         {
-            return await _response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            #if NET5_0_OR_GREATER
+                return await _response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            #else
+                return await _response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            #endif
         }
 
         /// <inheritdoc />

--- a/CryptoExchange.Net/Testing/Implementations/TestResponse.cs
+++ b/CryptoExchange.Net/Testing/Implementations/TestResponse.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CryptoExchange.Net.Testing.Implementations
@@ -32,6 +33,6 @@ namespace CryptoExchange.Net.Testing.Implementations
         {
         }
 
-        public Task<Stream> GetResponseStreamAsync() => Task.FromResult(_response);
+        public Task<Stream> GetResponseStreamAsync(CancellationToken cancellationToken) => Task.FromResult(_response);
     }
 }


### PR DESCRIPTION
### Issue:
I experienced that my application was hanging when using a cancellation token on REST requests.

### Cause:
The response header was read but not the body.

### Solution:
Pass the cancellation token to Content.ReadAsStreamAsync (only available in .NET5+)